### PR TITLE
A suggest for another way to disply the distro name

### DIFF
--- a/Titus.conkyrc
+++ b/Titus.conkyrc
@@ -147,7 +147,7 @@ ${color6}${voffset 4}${font GE Inspira:size=12}${alignc}${time %A} ${time %B} ${
 
 ${color5}${font Roboto:size=10}${voffset 2}S Y S T E M   ${hr 2}${font}${color}
 ${color2}${voffset 8}Hostname:${color} ${alignr}${nodename}
-${color2}Distro:${color}${alignr}$sysname $kernel ${alignr}${execi 6000 lsb_release -a | grep 'Release'|awk {'print $2""$3""$4""$5'}}
+${color2}Distro:${color}${alignr}$sysname ${alignr}${execi 6000 lsb_release -a | grep 'Description'|awk {'print $3, $4, $5'}}
 ${color2}Kernel:${color}${alignr}${exec uname} ${exec uname -r}
 #Nvidia: ${alignr}${execp  nvidia-smi --query-supported-clocks=gpu_name --format=csv,noheader}
 #Nvidia Driver: ${alignr}${execi 60000 nvidia-smi | grep "Driver Version"| awk {'print $3'}}


### PR DESCRIPTION
The change is test on Linux Mint 19.3 and Manjaro.

Example for Linux Mint:
Current result output:
Distro:       Linux 5.3.0-46-generic 19.3

Suggested change output results:
Distro:       Linux Mint 19.3 Tricia

Thanks for this great script there got me started with Conky - Cheers