### PR TITLE
Update Titus.conkyrc

### DIFF
--- a/Titus.conkyrc
+++ b/Titus.conkyrc
@@ -196,6 +196,6 @@ ${color2}${offset 30}Eth Down:${color} ${alignr}${offset -10$}${downspeed enp6s0
 #${font StyleBats:size=20}u${font}${offset 8}${voffset -12}GPU Temp ${alignr}${execi 60 nvidia-smi --query-gpu=temperature.gpu --format=csv,noheader} °C
 #${offset 30}Fan Speed ${alignr}${execi 60 nvidia-settings -q [fan:0]/GPUCurrentFanSpeed -t} %
 #${offset 30}GPU Clock ${alignr}${execi 60 nvidia-settings -q GPUCurrentClockFreqs | grep -m 1 Attribute | awk '{print $4}' | sed -e 's/\.//' | cut -d, -f1} MHz
-#${offset 30}Mem Clock ${alignr}${execi 86400 nvidia-settings -q all| grep -m 1 GPUCurrentProcessorClockFreqs | awk '{print $4}' | sed 's/.$//'} MHz
+#${offset 30}Mem Clock ${nvidia memfreq} MHz
 #${offset 30}Mem Used ${alignr}${execi 60 nvidia-settings -q [gpu:0]/UsedDedicatedGPUMemory -t} / ${exec nvidia-settings -q [gpu:0]/TotalDedicatedGPUMemory -t} MiB0
 ]];


### PR DESCRIPTION
GPUCurrentProcessorClockFreqs on line 199 does not seem to be a command any longer from what i could find in 'nvidia-settings'. Simply changing it all to 'nvidia memfreq' seems to have fixed it. This is my first suggested change ever so sorry if I did it wrong.