### PR TITLE
Update Titus.conkyrc

### DIFF
--- a/Titus.conkyrc
+++ b/Titus.conkyrc
@@ -192,7 +192,7 @@ ${color2}${offset 30}IP Address: ${color} ${alignr}${offset -10$}${addrs enp6s0}
 ${color2}${offset 30}Eth Up:${color} ${alignr}${offset -10$}${upspeed enp6s0}${alignr}${upspeedgraph enp6s0 8,100}
 ${color2}${offset 30}Eth Down:${color} ${alignr}${offset -10$}${downspeed enp6s0}${alignr}${downspeedgraph enp6s0 8,100}
 #${font Roboto:size=10}N V I D I A   ${hr 2}${font}
-#${font Roboto:size=10,weight:bold}${color5}${execp  nvidia-smi --query-supported-clocks=gpu_name --format=csv,noheader}${font}
+#${font Roboto:size=10:bold}${color5}${execp  nvidia-smi --query-supported-clocks=gpu_name --format=csv,noheader}${font}
 #${font StyleBats:size=20}u${font}${offset 8}${voffset -12}GPU Temp ${alignr}${execi 60 nvidia-smi --query-gpu=temperature.gpu --format=csv,noheader} °C
 #${offset 30}Fan Speed ${alignr}${execi 60 nvidia-settings -q [fan:0]/GPUCurrentFanSpeed -t} %
 #${offset 30}GPU Clock ${alignr}${execi 60 nvidia-settings -q GPUCurrentClockFreqs | grep -m 1 Attribute | awk '{print $4}' | sed -e 's/\.//' | cut -d, -f1} MHz


### PR DESCRIPTION
font Roboto:size=10,weight:bold}
Including weight gives me an error in terminal conky: can't load Xft font 'Roboto:size=10,weight:bold'
Changing to font Roboto:size=10:bold will fix the issue