### PR TITLE
Update conky-startup.sh

### DIFF
--- a/conky-startup.sh
+++ b/conky-startup.sh
@@ -1,2 +1,1 @@
-killall conky
 sleep 20s && conky -c "$HOME/.conky/Titus.conkyrc" &


### PR DESCRIPTION
When booting up, I type in my password to decrypt my PC. Then I get the error 'Error found when loading /etc/profile. conky: no process found. As a result the session will not be configured correctly. You should fix the problem as soon as feasible.' I am on popOS 20. The solution is to just omit 'killall conky' since there are apparently no conky processes loading.